### PR TITLE
Removed sliding_window size debugfs parameter

### DIFF
--- a/ar.h
+++ b/ar.h
@@ -1,8 +1,6 @@
 #if !defined AR_H
 #define AR_H
 
-// TODO: CHANGE AR_SW_SIZE IN AR_DEBUGFS.C AS WELL
-#define SLIDING_WINDOW_SIZE 25
 #define HIST_SIZE 5
 #define MAX_NO_CPUS 4
 

--- a/ar_debugfs.c
+++ b/ar_debugfs.c
@@ -25,7 +25,6 @@
  **************************************************************************/
 static u32 ar_regulation_time_ms = 1; //ms, default 1000ms
 static u32 ar_observation_time_ms = 1000;
-static u32 ar_sw_size = 25;  //If changing this change SLIDING_WINDOW_SIZE as well
 atomic_t enable_reg; // Memory regulation enabled or disabled via debugfs
 static struct dentry *ar_dir = NULL;
 
@@ -108,51 +107,6 @@ static int ar_obs_interval_open(struct inode *inode, struct file *filp)
     return single_open(filp, ar_obs_interval_show, NULL);
 }
 
-
-/****************************************
- * Fops functions for Sliding window size interval
- ****************************************/
-static ssize_t ar_sw_size_write(struct file *filp,
-                    const char __user *ubuf,
-                    size_t cnt, loff_t *ppos){
-
-    char buf[BUF_SIZE];
-    u32 tmp = 0 ;
-
-    if (copy_from_user(&buf, ubuf, (cnt > BUF_SIZE) ? BUF_SIZE: cnt) != 0)
-        return 0;
-
-    if (1){
-        pr_err("%s: Attempted changing window size to %s, not supported \n",__func__, buf);
-        return 0;
-    }
-    
-    pr_info("%s: Received %s",__func__,buf);
-
-    int ret = kstrtou32(buf, 10, &tmp);
-
-    if (ret){
-        pr_err("%s: ret %d",__func__,ret);
-        return ret;
-    }
-
-    ar_sw_size = tmp;
-    return cnt;
-}
-
-static int ar_sw_size_read(struct seq_file *m, void *v)
-{
-    int tmp = ar_sw_size;
-    // pr_info("%s: Reading.",__func__);
-    seq_printf(m, "%u \n",tmp);
-    return 0;
-}
-
-
-static int ar_sw_size_open(struct inode *inode, struct file *filp)
-{
-    return single_open(filp,ar_sw_size_read , NULL);
-}
 /******************************************************
  Fops functions for enable/disable regulation interval
 ******************************************************/
@@ -232,12 +186,7 @@ static const struct file_operations ar_reg_interval_fops = {
     .release    = single_release,
 };
 
-static const struct file_operations ar_sliding_window_size = {
-    .open       = ar_sw_size_open,
-    .write      = ar_sw_size_write,
-    .read       = seq_read,
-    .release    = single_release,
-};
+
 static const struct file_operations ar_enable_reg = {
     .open       = ar_enable_reg_open,
     .write      = ar_enable_reg_write,
@@ -254,8 +203,6 @@ int ar_init_debugfs(void)
                 &ar_reg_interval_fops);
     debugfs_create_file("obs_interval", 0444, ar_dir, NULL,
                 &ar_obs_interval_fops);
-    debugfs_create_file("sliding_window_size", 0444, ar_dir, NULL,
-            &ar_sliding_window_size);
     debugfs_create_file("enable_regulation", 0444, ar_dir, NULL,
                         &ar_enable_reg);
     return 0;
@@ -269,6 +216,3 @@ u32  get_regulation_time(void){
 	return ar_regulation_time_ms;
 }
 
-u32 inline get_sliding_window_size(void){
-    return ar_sw_size;
-}


### PR DESCRIPTION
The sliding window size parameter is was introdcued to implement sliding window method while perfoming the PID controller , which is now replaced by the LMS regulator